### PR TITLE
Added git filter that strips jupyter notebooks of output. 

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,0 +1,12 @@
+#!/bin/bash 
+
+# git filter to strip notebooks of output
+config="[filter \"nbstrip_full\"]\n clean = \"jq --indent 1 '(.cells[] | select(has(\\\"outputs\\\")) | .outputs) = []  | (.cells[] | select(has(\\\"execution_count\\\")) | .execution_count) = null  | .metadata = {\\\"language_info\\\": {\\\"name\\\": \\\"python\\\", \\\"pygments_lexer\\\": \\\"ipython3\\\"}} | .cells[].metadata = {} '\"\n smudge = cat\n required = true\n "
+
+git init  # Create git repo
+echo -e $config >> .git/config  # Copy git filter
+
+git add .
+git commit -am"Setup Nesta Data Science cookiecutter"
+
+

--- a/{{ cookiecutter.repo_name }}/.gitattributes
+++ b/{{ cookiecutter.repo_name }}/.gitattributes
@@ -1,0 +1,14 @@
+*.ipynb filter=nbstrip_full
+
+## Add the following to .git/config and install jq (https://stedolan.github.io/jq/download/)
+## (This can also be done by running `make git` to add to the local .gitconfig and 
+## `make requirements` to install jq)
+#[filter "nbstrip_full"]
+#  clean = "jq --indent 1 \
+#            '(.cells[] | select(has(\"outputs\")) | .outputs) = []  \
+#            | (.cells[] | select(has(\"execution_count\")) | .execution_count) = null  \
+#            | .metadata = {\"language_info\": {\"name\": \"python\", \"pygments_lexer\": \"ipython3\"}} \
+#            | .cells[].metadata = {} \
+#            '"
+#  smudge = cat
+#  required = true

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -20,6 +20,11 @@ endif
 # COMMANDS                                                                      #
 #################################################################################
 
+## Setup git filter for notebooks
+git: 
+	echo -e "[filter \"nbstrip_full\"]\n clean = \"jq --indent 1 '(.cells[] | select(has(\\\"outputs\\\")) | .outputs) = []  | (.cells[] | select(has(\\\"execution_count\\\")) | .execution_count) = null  | .metadata = {\\\"language_info\\\": {\\\"name\\\": \\\"python\\\", \\\"pygments_lexer\\\": \\\"ipython3\\\"}} | .cells[].metadata = {} '\"\n smudge = cat\n required = true\n " >> .git/config
+
+
 ## Install Python Dependencies
 requirements: test_environment
 	$(PYTHON_INTERPRETER) -m pip install -U pip setuptools wheel


### PR DESCRIPTION
Issue #5 This is installed by default by the cookiecutter. A `make git` command is also available that installs the filter for any user who forks/clones the repository.