### PR TITLE
make lint formats w/ black and lints w/ flake8. Max line len up to 88.

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -64,9 +64,9 @@ clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
 
-## Lint using black
+## Format using black and lint w/ flake8
 lint:
-	black {{ cookiecutter.repo_name }}
+	black {{ cookiecutter.repo_name }}; flake8 {{ cookiecutter.repo_name }}
 
 ## Upload Data to S3
 sync_data_to_s3:

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 79
+max-line-length = 88
 max-complexity = 10


### PR DESCRIPTION
(88 gives 10% tolerance and aligns with black)