### PR TITLE
Updated dependencies

### DIFF
--- a/{{ cookiecutter.repo_name }}/conda_environment.yaml
+++ b/{{ cookiecutter.repo_name }}/conda_environment.yaml
@@ -10,13 +10,17 @@ dependencies:
   - pandas
   - matplotlib
   - jupyter
+  - jupyterlab
   - ipython
+  - clang_osx-64
+  - gcc_linux-64
   # Put any conda dependencies here
 
   - pip:
     # Put any pip dependencies here (and no conda ones anywhere below)
 
   # Tooling requirements (don't edit)
+    - tornado>=5.0  # Required to stop luigi from breaking jupyter
     - tqdm
     - pyyaml
     - tables


### PR DESCRIPTION
- Added jupyterlab (Closes #44)
- Added gcc (linux) + clang (OSX) which are required by conda to compile packages w/ C extensions
- Constrained tornado requirement to stop luigi breaking jupyter (see https://github.com/spotify/luigi/pull/2761)